### PR TITLE
feat: 🎸 reproduction of parameters not respected

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,12 @@ module.exports = {
   addons: ['@storybook/addon-links', '@storybook/addon-essentials', "@storybook/addon-styling"],
   framework: {
     name: '@storybook/nextjs',
-    options: {},
+    options: {
+      image: {
+        loading: 'eager',
+        unoptimized: true,
+      },
+    },
   },
   staticDirs: ['../public'],
   docs: {

--- a/stories/pages/nextjsImages.stories.jsx
+++ b/stories/pages/nextjsImages.stories.jsx
@@ -3,6 +3,14 @@ import NextjsImages from '../../pages/nextjsImages'
 export default {
   title: 'Pages',
   component: NextjsImages,
+  parameters: {
+    nextjs: {
+      image: {
+        loading: 'eager',
+        unoptimized: true,
+      },
+    }
+  }
 }
 
 export const NextjsImagesPage = () => <NextjsImages />


### PR DESCRIPTION
Setting the parameters for `next/image` as [documented](https://github.com/storybookjs/storybook/blob/next/code/frameworks/nextjs/README.md#options) not works

You can see the reproduction with the steps bellow.
1. Pull this PR.
2. `yarn run storybook` or `yarn build-storybook && yarn serve-storybook`
3. Go to `http://localhost:3000/?path=/story/pages--nextjs-images-page`


<img width="960" alt="image" src="https://github.com/kodai3/with-jest-storybook/assets/33568829/68d8f164-3749-49ae-8602-a1256c89ecc9">
